### PR TITLE
feat: define ai-evidence-url attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,6 +887,21 @@
       </section>
 
       <section>
+        <h3>IETF Cryptographic Proof of Effort (CPOE)</h3>
+        <p>
+          <a href="https://datatracker.ietf.org/doc/draft-condrey-rats-pop-protocol/">IETF CPOE</a>
+          (formerly Proof of Process) provides a cryptographic attestation of
+          human effort expended during content creation. CPOE and this
+          specification are complementary layers of a single trust stack:
+          <code>ai-disclosure</code> provides the semantic signal, while
+          CPOE provides the verifiable evidence that supports that signal.
+          By linking an HTML element to a CPOE witness via the
+          <code>ai-evidence-url</code> attribute, authors can upgrade a
+          voluntary disclosure to a machine-verifiable claim.
+        </p>
+      </section>
+
+      <section>
         <h3>IBM AI Attribution Toolkit</h3>
         <p>
           The

--- a/index.html
+++ b/index.html
@@ -44,8 +44,8 @@
         to declare the degree of AI involvement in web content at both page
         level and element level. It also defines optional metadata attributes
         (<code>ai-model</code>, <code>ai-provider</code>,
-        <code>ai-prompt-url</code>) for supplementary information about the AI
-        systems used.
+        <code>ai-prompt-url</code>, <code>ai-evidence-url</code>) for
+        supplementary information about the AI systems used.
       </p>
     </section>
 
@@ -571,6 +571,35 @@
           ignore it and behave as if the attribute were absent.
         </p>
       </section>
+
+      <section>
+        <h3>
+          <code><dfn data-dfn-type="element-attr">ai-evidence-url</dfn></code>
+        </h3>
+        <p>
+          A [^URL^] pointing to a machine-verifiable evidence resource that
+          supports the disclosure claim — for example, a
+          <a href="https://datatracker.ietf.org/doc/draft-condrey-rats-pop-protocol/"
+            >CPOE</a
+          >
+          witness report, a
+          <a href="https://spec.c2pa.org/">C2PA</a> manifest, or a
+          <a href="https://www.w3.org/TR/vc-data-model-2.0/"
+            >Verifiable Credential</a
+          >.
+        </p>
+        <p>
+          This attribute enables authors to upgrade a voluntary disclosure to a
+          machine-verifiable claim by linking to cryptographic evidence of the
+          content creation process.
+        </p>
+        <p>
+          This attribute MAY be present on elements with any
+          <a>disclosure value</a>, including <code>none</code>, where it can
+          link to evidence of human-only authorship (e.g., a CPOE Written
+          Authorship Report).
+        </p>
+      </section>
     </section>
 
     <!-- ============================================================ -->
@@ -697,6 +726,29 @@
           Note: <code>ai-disclosure="human-only"</code> is a positive assertion.
           The <em>absence</em> of the attribute means "unknown," not
           "human-only."
+        </p>
+      </section>
+
+      <section>
+        <h3>Evidence-backed disclosure</h3>
+        <p>
+          An author links their disclosure to cryptographic evidence of human
+          authorship:
+        </p>
+        <pre class="example html">
+&lt;article ai-disclosure="none"
+         ai-evidence-url="/evidence/war-2026-05.cbor"&gt;
+  &lt;h1&gt;Analysis: Supply Chain Risks in 2026&lt;/h1&gt;
+  &lt;p&gt;After reviewing three months of shipping data...&lt;/p&gt;
+&lt;/article&gt;
+        </pre>
+        <p>
+          The <code>ai-evidence-url</code> links to a
+          <a href="https://datatracker.ietf.org/doc/draft-condrey-rats-pop-protocol/"
+            >CPOE</a
+          >
+          Written Authorship Report, enabling verifiers to confirm the
+          human-authorship claim cryptographically.
         </p>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -595,7 +595,7 @@
         </p>
         <p>
           This attribute MAY be present on elements with any
-          <a>disclosure value</a>, including <code>none</code>, where it can
+          <a>disclosure value</a>, including <code>human-only</code>, where it can
           link to evidence of human-only authorship (e.g., a CPOE Written
           Authorship Report).
         </p>
@@ -736,7 +736,7 @@
           authorship:
         </p>
         <pre class="example html">
-&lt;article ai-disclosure="none"
+&lt;article ai-disclosure="human-only"
          ai-evidence-url="/evidence/war-2026-05.cbor"&gt;
   &lt;h1&gt;Analysis: Supply Chain Risks in 2026&lt;/h1&gt;
   &lt;p&gt;After reviewing three months of shipping data...&lt;/p&gt;


### PR DESCRIPTION
## Summary
- Formally defines `ai-evidence-url` as an optional metadata attribute alongside `ai-model`, `ai-provider`, and `ai-prompt-url`
- Updates abstract to include the new attribute
- Adds an "Evidence-backed disclosure" use case example

Addresses #13 — the attribute was referenced in the CPOE alignment section but never formally defined.

## Context
The three-layer provenance model:
- **W3C `ai-disclosure`**: semantic signal (this spec)
- **C2PA**: identity/provenance
- **IETF CPOE**: verifiable evidence of human effort

`ai-evidence-url` bridges the semantic layer to the evidence layer, enabling machine-verifiable disclosure claims.

## Test plan
- Open `index.html` in a browser to verify ReSpec renders correctly
- Confirm the new attribute appears in the spec's defined terms
- Verify cross-references resolve

---

[![AI Disclosure: ai-assisted](https://img.shields.io/badge/AI_Disclosure-ai--assisted-6B7280?style=flat-square)](https://github.com/dcondrey/ai-disclosure-badges/blob/main/docs/ai-assisted.md)
