### PR TITLE
fix: clarify deterministic means the computer-science sense

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,8 +195,11 @@
         </dd>
         <dt><dfn>generative AI</dfn></dt>
         <dd>
-          Systems trained on data that produce novel outputs through inference,
-          as opposed to deterministic tools that apply fixed rules. See
+          Systems trained on data that produce novel outputs through
+          inference, as opposed to <dfn>deterministic</dfn> tools that apply
+          fixed rules. "Deterministic" is used here in the computer-science
+          sense: given the same input, the tool always produces the same
+          output, with no learned or inferred behavior. See
           <a href="#boundary-guidance">Boundary guidance</a> for detailed
           guidance.
         </dd>
@@ -317,8 +320,8 @@
         <h3>Boundary guidance ("What counts as AI?")</h3>
         <p>
           The boundary is <a>generative AI</a> — systems trained on data that
-          produce novel outputs through inference. Deterministic tools that
-          apply fixed rules are not covered.
+          produce novel outputs through inference. <a>Deterministic</a> tools
+          that apply fixed rules are not covered.
         </p>
         <p>The following categories provide guidance for authors:</p>
         <p><strong>Not AI</strong> (no disclosure needed):</p>


### PR DESCRIPTION
Follow-up to #9 (already partly addressed by #30). mitchellevan pointed out that "deterministic" has several meanings outside computer science, and the spec didn't say which one it meant.

Adds a `dfn` for the term and one clarifying sentence: given the same input, the tool always produces the same output, with no learned or inferred behavior. Links it from Boundary guidance where it's first used in context.

---

[![AI Disclosure: ai-assisted](https://img.shields.io/badge/AI_Disclosure-ai--assisted-6B7280?style=flat-square)](https://github.com/dcondrey/ai-disclosure-badges/blob/main/docs/ai-assisted.md)
